### PR TITLE
Add linktree to Get Involved page

### DIFF
--- a/_pages/get-involved.md
+++ b/_pages/get-involved.md
@@ -6,4 +6,4 @@ permalink: /get-involved/
 
 Want to get involved with Central NJ DSA? [Join us!](https://act.dsausa.org/donate/dsa_recommit_2022/)
 
-Join us at a Chapter meeting or event! Check out [our Calendar](../calendar)
+Join us at a Chapter meeting or event! Check out [the chapter linktree](https://linktr.ee/CentralJerseyDSA) for upcoming events!


### PR DESCRIPTION
Since we don't have a proper calendar yet, I am pointing the Get Involved page to our linktree for the time being.